### PR TITLE
fix: drop ShellJS in favor of child_process

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -8,8 +8,7 @@
 
 var NodeHelper = require('node_helper');
 var mqtt = require('mqtt');
-var shell = require('shelljs');
-shell.config.execPath = '/usr/bin/node';
+var { exec } = require('child_process');
 
 module.exports = NodeHelper.create({
 
@@ -76,12 +75,12 @@ module.exports = NodeHelper.create({
 
     // Turn display (hdmi) on
     turnDisplayOn: function() {
-        shell.exec('vcgencmd display_power 1 >/dev/null 2>&1');
+        exec('vcgencmd display_power 1 >/dev/null 2>&1');
     },
 
     // Turn display (hdmi) off
     turnDisplayOff: function() {
-        shell.exec('vcgencmd display_power 0 >/dev/null 2>&1');
+        exec('vcgencmd display_power 0 >/dev/null 2>&1');
     }
 
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-toggle-by-mqtt",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shows/hides MagicMirror modules on mqtt command",
   "main": "mmm-toggle-by-mqtt.js",
   "scripts": {
@@ -14,7 +14,6 @@
   "author": "Moritz Kraus",
   "license": "MIT",
   "dependencies": {
-    "mqtt": "^3.0.0",
-    "shelljs": "^0.8.3"
+    "mqtt": "^3.0.0"
   }
 }


### PR DESCRIPTION
This fixes #1 by avoiding https://github.com/shelljs/shelljs/issues/1024 and still leaves the original functionality intact.